### PR TITLE
Move API keys to MongoDB

### DIFF
--- a/coffee/helper/cache.litcoffee
+++ b/coffee/helper/cache.litcoffee
@@ -1,4 +1,3 @@
-
 ## getFilter()
 
 Get data filter to use in caching.


### PR DESCRIPTION
Move API keys to MongoDB and cache them in Redis.
- [x] API keys test data
- [x] API keys caching
- [ ] Rate limiting
- [ ] HTTP errors
