### PR TITLE
Parse postnummer field as string

### DIFF
--- a/coffee/helper/schema.litcoffee
+++ b/coffee/helper/schema.litcoffee
@@ -100,7 +100,7 @@ There optional are optional for all objects.
           tittel: joi.string()
           adresse1: joi.string()
           adresse2: joi.string()
-          postnummer: joi.number().integer()
+          postnummer: joi.string()
           poststed: joi.string()
           land: joi.string()
           telefon: joi.string()


### PR DESCRIPTION
Since this field may start with a leading zero, it makes more sense to
parse it as a string. This helps clients avoid having to manually handle
those cases by adding a leading zero so that it's not rendered with only
3 digits.

See for example:
- http://ut.no/gruppe/8.1284/
- http://ut.no/gruppe/8.1238/
