### PR TITLE
chore(dependency): require lte 1.30 of newrelic

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "joi": "^5.1.0",
     "mongo-querystring": "^3.1.0",
     "mongodb": "^2.1.18",
-    "newrelic": "^1.28.0",
+    "newrelic": "<=1.30.0",
     "raven": "^0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Newer version is suspected to be reason for invalid responses
```
{
  message: Cannot read property 'start' of null
}
```
from Nasjonal Turbase.