### PR TITLE
chore(npm): correct repository props

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": null,
   "description": "API for Nasjonal Turbase",
   "homepage": "http://www.nasjonalturbase.no/",
-  "bugs": "https://github.com/turistforeningen/nasjonalturbase/issues",
-  "repository": "git@github.com:Turistforeningen/nasjonalturbase.git",
+  "bugs": "https://github.com/Turbasen/Turbasen/issues",
+  "repository": "git@github.com:Turbasen/Turbasen.git",
   "main": "src/server.js",
   "files": [
     "src"


### PR DESCRIPTION
To prevent npm publish from failing.