### PR TITLE
feat(document): increase limit for expand

### DIFF
--- a/coffee/model/Document.litcoffee
+++ b/coffee/model/Document.litcoffee
@@ -246,7 +246,7 @@ unauthorized information disclosure.
       if Object.keys(subFields).length is 0
         subFields.privat = false
 
-      limit = Math.min opts.limit or 10, 10
+      limit = Math.min opts.limit or 20, 50
       query = opts.query or {}
 
       count = 0


### PR DESCRIPTION
Increase limits for expand, to be able to get all of the related objects for objects with many related objects.