### PR TITLE
Increase limits for collection and expand

### DIFF
--- a/coffee/collection.litcoffee
+++ b/coffee/collection.litcoffee
@@ -109,7 +109,7 @@ Make new cursor object with the correct query, fields, and other options (limit,
 skip, and sort).
 
       cursor = req.db.col.find req.db.query, fields,
-        limit: Math.min (parseInt(req.query.limit, 10) or 20), 50
+        limit: Math.min (parseInt(req.query.limit, 10) or 20), 100
         skip: parseInt(req.query.skip, 10) or 0
         sort: sort
       .maxTimeMS parseInt(process.env.DATABASE_TIMEOUT_MS, 10)

--- a/coffee/model/Document.litcoffee
+++ b/coffee/model/Document.litcoffee
@@ -246,7 +246,7 @@ unauthorized information disclosure.
       if Object.keys(subFields).length is 0
         subFields.privat = false
 
-      limit = Math.min opts.limit or 20, 50
+      limit = Math.min opts.limit or 20, 100
       query = opts.query or {}
 
       count = 0

--- a/test/integration/collection-int.coffee
+++ b/test/integration/collection-int.coffee
@@ -49,11 +49,11 @@ describe 'GET', ->
         .expect (res) ->
           assert.equal res.body.count, 10
 
-    it 'should prevent limit higher then 50', ->
-      req.get '/steder?limit=100&api_key=dnt'
+    it 'should prevent limit higher then 100', ->
+      req.get '/steder?limit=200&api_key=dnt'
         .expect 200
         .expect (res) ->
-          assert.equal res.body.count, 50
+          assert.equal res.body.count, 100
 
   describe '?skip', ->
     it 'should skip the 9 first documents', (done) ->


### PR DESCRIPTION
Necessary for the SjekkUT app, which is relying on the expand feature.